### PR TITLE
Added php requirements in composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         }
     },
     "require": {
+        "php": ">=7.1.0",
         "yiisoft/yii2": "^2.0@dev",
         "yiisoft/yii2-httpclient": "~2.0.0"
     },


### PR DESCRIPTION
To avoid missing class errors with type hinting like `void` on a php's lower versions.